### PR TITLE
Bugfix/route instructions

### DIFF
--- a/src/components/explore/ExploreContainer.tsx
+++ b/src/components/explore/ExploreContainer.tsx
@@ -223,7 +223,10 @@ const ExploreContainer: React.FC<ContainerProps> = ({place}) => {
       },
       async (data: RouteReadyCallbackData) => {
         console.log('Route added', data);
+        let routeData = data.data as any
+        let steps = routeData.legs[0].steps as StepDTO[]
         setRouteId(data.routeId);
+        setSteps(steps)
         presentToast('top', 'Route loaded');
       },
     );

--- a/src/components/explore/ExploreContainer.tsx
+++ b/src/components/explore/ExploreContainer.tsx
@@ -2,6 +2,8 @@ import './ExploreContainer.css';
 import { LazarilloMap, LazarilloUtils } from '@lzdevelopers/lazarillo-maps';
 import { useEffect, useRef, useState } from 'react';
 import {
+  IonAccordion,
+  IonAccordionGroup,
   IonButton,
   IonButtons,
   IonCard,
@@ -757,27 +759,22 @@ const ExploreContainer: React.FC<ContainerProps> = ({place}) => {
         ) : (<IonText></IonText>)
         }
 
-
-
-        {steps.length > 0 ? (
-          <IonRow>
-            <IonCol>
-              <IonTitle>Current Route Instructions:</IonTitle>
-            </IonCol>
-          </IonRow>) : ''}
-
-        {steps.length > 0 ? (
-          <IonRow>
-            <IonCol>
-              <IonList>
+        {steps.length > 0 && (
+          <IonAccordionGroup>
+            <IonAccordion value="first">
+              <IonItem slot="header" color='light'>
+                <IonLabel><h1>Current Route Instructions</h1></IonLabel>
+              </IonItem>
+              <IonList slot="content">
                 {steps.map((step, i) => (
                   <IonItem key={i}>
-                    <IonText>{step.html_instructions}</IonText>
+                    <IonText color={currentPositionState?.routingStatus?.currentStep == i ? 'primary': ''}>{step.html_instructions}</IonText>
                   </IonItem>
                 ))}
               </IonList>
-            </IonCol>
-          </IonRow>) : ''}
+            </IonAccordion>
+          </IonAccordionGroup>
+        )}
 
         <IonModal id="example-modal" isOpen={isOpen} className="ion-padding modal-demo">
           <IonHeader>


### PR DESCRIPTION
# Mostrar Instrucciones de la ruta

## Por que se hizo?

Para mostrar la lista de instrucciones de la ruta actual dentro de la demo.

## Que se hizo

- Se guardo la informacion de los *steps* de la ruta actual dentro de la variable que ya existia dentro de la demo.
- Se modifico la vista del listado de instrucciones para ocupar un elemento colapsable, ademas se destaca la instrucción actual con un color diferente.

## Que probar
- Se debe verificar que se vean en forma correcta todos los aspectos visuales en Android ya que solo probe en iOS.
- Se debe verificar que se coloree la instruccion correctamente. Este depende de la variable *currentStep* en *routingStatus* por lo que si no aparece ninguna instruccion coloreada, verificar que este valor sea distinto de **-1**.