### PR TITLE
Feature/select parent place

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Redirect, Route } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { IonApp, IonRouterOutlet, setupIonicReact } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 import Home from './pages/home/Home';
@@ -22,6 +22,9 @@ import '@ionic/react/css/display.css';
 /* Theme variables */
 import './theme/variables.css';
 
+import ExploreContainer from './components/explore/ExploreContainer';
+import Explorer from './pages/explorer/Explorer';
+
 setupIonicReact();
 
 const App: React.FC = () => (
@@ -34,6 +37,7 @@ const App: React.FC = () => (
         <Route exact path="/">
           <Redirect to="/home" />
         </Route>
+        <Route path="/place/:alias" component={Explorer}/>
       </IonRouterOutlet>
     </IonReactRouter>
   </IonApp>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Redirect, Route } from 'react-router-dom';
 import { IonApp, IonRouterOutlet, setupIonicReact } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 import Home from './pages/home/Home';
@@ -22,7 +22,6 @@ import '@ionic/react/css/display.css';
 /* Theme variables */
 import './theme/variables.css';
 
-import ExploreContainer from './components/explore/ExploreContainer';
 import Explorer from './pages/explorer/Explorer';
 
 setupIonicReact();

--- a/src/components/explore/ExploreContainer.tsx
+++ b/src/components/explore/ExploreContainer.tsx
@@ -101,7 +101,7 @@ const ExploreContainer: React.FC<ContainerProps> = ({alias}) => {
 
       await LazarilloMap.initializeLazarilloPlugin({
         apiKey: apiKey,
-        place: alias
+        place: parentPlaceRef.current.id
       })
       setInitialized(true);
     }

--- a/src/components/explore/ExploreContainer.tsx
+++ b/src/components/explore/ExploreContainer.tsx
@@ -46,9 +46,6 @@ interface ContainerProps{
 
 const ExploreContainer: React.FC<ContainerProps> = ({alias}) => {
 
-  let unitSystem = "METRIC" //default value
-  let announceSystem = "RELATIVE" //default value
-  let withMobility: boolean = false //default value
 
   const parentPlaceRef = useRef<Place>({
         id: '',

--- a/src/components/explore/ExploreContainer.tsx
+++ b/src/components/explore/ExploreContainer.tsx
@@ -38,11 +38,11 @@ import { Place } from '../places/Place';
 import { InnerFloor } from '../places/InnerFloor';
 
 
-interface ContainerProps {
-  place: Place | undefined
+interface ContainerProps{
+  alias: string
  }
 
-const ExploreContainer: React.FC<ContainerProps> = ({place}) => {
+const ExploreContainer: React.FC<ContainerProps> = ({alias}) => {
 
 
   let unitSystem = "METRIC" //default value

--- a/src/components/explore/ExploreContainer.tsx
+++ b/src/components/explore/ExploreContainer.tsx
@@ -44,7 +44,6 @@ interface ContainerProps{
 
 const ExploreContainer: React.FC<ContainerProps> = ({alias}) => {
 
-
   let unitSystem = "METRIC" //default value
   let announceSystem = "RELATIVE" //default value
   let withMobility: boolean = false //default value

--- a/src/components/select/SelectParentPlaceContainer.css
+++ b/src/components/select/SelectParentPlaceContainer.css
@@ -1,3 +1,7 @@
 .center-row{
-    align-content: center;
+    justify-content: center;
+}
+
+.button-style{
+    justify-content: end;
 }

--- a/src/components/select/SelectParentPlaceContainer.tsx
+++ b/src/components/select/SelectParentPlaceContainer.tsx
@@ -1,28 +1,28 @@
 import './SelectParentPlaceContainer.css'
 
 import { LazarilloUtils } from '@lzdevelopers/lazarillo-maps';
-import { IonButton, IonCol, IonContent, IonGrid, IonRow, IonSelect, IonSelectOption } from "@ionic/react";
-import ExploreContainer from "../explore/ExploreContainer";
+import { IonButton, IonCol, IonContent, IonGrid, IonItem, IonLabel, IonRadio, IonRadioGroup, IonRow, useIonViewWillEnter } from "@ionic/react";
 import { useEffect, useState } from 'react';
-
+import { useHistory } from 'react-router-dom';
 import { Place } from '../places/Place';
 
 interface ContainerProps { 
-    handleTitle: (t: string) => void;
+
 }
 
-const SelectParentPlaceContainer: React.FC<ContainerProps> = ({handleTitle}) => {
-    const [showExplore, setShowExplore] = useState(false);
+const SelectParentPlaceContainer: React.FC<ContainerProps> = () => {
     const [parentPlacesList, setParentPlacesList] = useState<Place[]>([]);
     const [parentPlaceSelected, setParentPlace] = useState<Place>();
+
+    const history = useHistory();
 
     const apiKey = process.env.REACT_APP_YOUR_API_KEY_HERE
     ? process.env.REACT_APP_YOUR_API_KEY_HERE
     : '';
 
-    useEffect(() => {
+    useIonViewWillEnter(() => {
         getParentPlaces()
-    }, [parentPlacesList])
+    });
 
     const showParentPlaceMap = (e: CustomEvent) => {
         const placeId = e.detail.value;
@@ -42,40 +42,42 @@ const SelectParentPlaceContainer: React.FC<ContainerProps> = ({handleTitle}) => 
     }
 
     const handleOnClick = () => {
-        setShowExplore(true);
-        handleTitle(parentPlaceSelected !== undefined ? parentPlaceSelected.title.default : "");
+        console.log(parentPlaceSelected?.alias);
+        if (parentPlaceSelected !== undefined){
+            history.push(`/place/${parentPlaceSelected.alias}`);
+        }
     }
     
 
     return (
-            showExplore ? <ExploreContainer place={parentPlaceSelected}/> : 
-            <IonContent>
-                <IonGrid>
-                    <IonCol>
-                        <IonRow className='center-row'>
-                            Select a parent place to use the map:
-                        </IonRow>
-                        <IonRow className='center-row'>
-                            <IonSelect
-                                interface='popover'
-                                placeholder="Select place"
-                                onIonChange={showParentPlaceMap}>
-                                {
-                                    parentPlacesList.map((place) => {
-                                        return (<IonSelectOption value={place.id}>{place.title.default}</IonSelectOption>)
-                                    })
-                                }
-                                
-                            </IonSelect>
-                        </IonRow>
-                        <IonRow className='button-style'>
-                            <IonButton onClick={handleOnClick}>
-                                Show Map
-                            </IonButton>
-                        </IonRow>
-                    </IonCol>
-                </IonGrid>
-            </IonContent>
+            <IonGrid>
+                <IonCol>
+                    <IonRow className='center-row'>
+                        Select a parent place to use the map:
+                    </IonRow>
+                    <IonRow className='center-row'>
+                        <IonRadioGroup
+                            onIonChange={showParentPlaceMap}>
+                            {
+                                parentPlacesList.map((place) => {
+                                    return (
+                                        <IonItem>
+                                            <IonLabel>{place.title.default}</IonLabel>
+                                            <IonRadio mode="ios" slot="end" value={place.id}></IonRadio>
+                                        </IonItem>
+                                    )
+                                })
+                            }
+                            
+                        </IonRadioGroup>
+                    </IonRow>
+                    <IonRow className='button-style'>
+                        <IonButton onClick={handleOnClick}>
+                            Show Map
+                        </IonButton>
+                    </IonRow>
+                </IonCol>
+            </IonGrid>
     )
 }
 export default SelectParentPlaceContainer;

--- a/src/components/select/SelectParentPlaceContainer.tsx
+++ b/src/components/select/SelectParentPlaceContainer.tsx
@@ -2,7 +2,7 @@ import './SelectParentPlaceContainer.css'
 
 import { LazarilloUtils } from '@lzdevelopers/lazarillo-maps';
 import { IonButton, IonCol, IonContent, IonGrid, IonItem, IonLabel, IonRadio, IonRadioGroup, IonRow, useIonViewWillEnter } from "@ionic/react";
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Place } from '../places/Place';
 
@@ -28,7 +28,6 @@ const SelectParentPlaceContainer: React.FC<ContainerProps> = () => {
     const showParentPlaceMap = (e: CustomEvent) => {
         const placeId = e.detail.value;
         console.log("num of places", parentPlacesList.length)
-        console.log("selected place id: ", placeId)
         const parentPlace = parentPlacesList.find(p => p.id === placeId)
         setParentPlace(parentPlace);
         setIsSelected(false);

--- a/src/components/select/SelectParentPlaceContainer.tsx
+++ b/src/components/select/SelectParentPlaceContainer.tsx
@@ -7,9 +7,11 @@ import { useEffect, useState } from 'react';
 
 import { Place } from '../places/Place';
 
-interface ContainerProps { }
+interface ContainerProps { 
+    handleTitle: (t: string) => void;
+}
 
-const SelectParentPlaceContainer: React.FC<ContainerProps> = () => {
+const SelectParentPlaceContainer: React.FC<ContainerProps> = ({handleTitle}) => {
     const [showExplore, setShowExplore] = useState(false);
     const [parentPlacesList, setParentPlacesList] = useState<Place[]>([]);
     const [parentPlaceSelected, setParentPlace] = useState<Place>();
@@ -39,6 +41,12 @@ const SelectParentPlaceContainer: React.FC<ContainerProps> = () => {
         })
     }
 
+    const handleOnClick = () => {
+        setShowExplore(true);
+        handleTitle(parentPlaceSelected !== undefined ? parentPlaceSelected.title.default : "");
+    }
+    
+
     return (
             showExplore ? <ExploreContainer place={parentPlaceSelected}/> : 
             <IonContent>
@@ -60,8 +68,11 @@ const SelectParentPlaceContainer: React.FC<ContainerProps> = () => {
                                 
                             </IonSelect>
                         </IonRow>
-                        <IonButton
-                        onClick={() => setShowExplore(true)}>Show Map</IonButton>
+                        <IonRow className='button-style'>
+                            <IonButton onClick={handleOnClick}>
+                                Show Map
+                            </IonButton>
+                        </IonRow>
                     </IonCol>
                 </IonGrid>
             </IonContent>

--- a/src/components/select/SelectParentPlaceContainer.tsx
+++ b/src/components/select/SelectParentPlaceContainer.tsx
@@ -11,6 +11,7 @@ interface ContainerProps {
 }
 
 const SelectParentPlaceContainer: React.FC<ContainerProps> = () => {
+    const [isSelected, setIsSelected] = useState(true);
     const [parentPlacesList, setParentPlacesList] = useState<Place[]>([]);
     const [parentPlaceSelected, setParentPlace] = useState<Place>();
 
@@ -30,6 +31,7 @@ const SelectParentPlaceContainer: React.FC<ContainerProps> = () => {
         console.log("selected place id: ", placeId)
         const parentPlace = parentPlacesList.find(p => p.id === placeId)
         setParentPlace(parentPlace);
+        setIsSelected(false);
     }
 
     const getParentPlaces = async () => {
@@ -72,7 +74,7 @@ const SelectParentPlaceContainer: React.FC<ContainerProps> = () => {
                         </IonRadioGroup>
                     </IonRow>
                     <IonRow className='button-style'>
-                        <IonButton onClick={handleOnClick}>
+                        <IonButton disabled={isSelected} onClick={handleOnClick}>
                             Show Map
                         </IonButton>
                     </IonRow>

--- a/src/pages/explorer/Explorer.tsx
+++ b/src/pages/explorer/Explorer.tsx
@@ -5,7 +5,6 @@ import { useParams } from 'react-router';
 
 const Explorer: React.FC = () => {
   const {alias} = useParams<{alias: string}>();
-  console.log("explorer alias", alias);
 
   return (
     <IonPage>

--- a/src/pages/explorer/Explorer.tsx
+++ b/src/pages/explorer/Explorer.tsx
@@ -1,0 +1,27 @@
+import { IonBackButton, IonButtons, IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import ExploreContainer from '../../components/explore/ExploreContainer';
+import { caretBack } from 'ionicons/icons';
+import { useParams } from 'react-router';
+
+const Explorer: React.FC = () => {
+  const {alias} = useParams<{alias: string}>();
+  console.log("explorer alias", alias);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot='start'>
+            <IonBackButton icon={caretBack} defaultHref="/home"></IonBackButton>
+          </IonButtons>
+          <IonTitle>Explorer</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        <ExploreContainer alias={alias} />
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default Explorer;

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,8 +1,7 @@
-import { IonBackButton, IonButtons, IonContent, IonHeader, IonIcon, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 import SelectParentPlaceContainer from '../../components/select/SelectParentPlaceContainer';
 import './Home.css';
-import { bagOutline, caretBack } from 'ionicons/icons';
-import { useState } from 'react';
+
 
 const Home: React.FC = () => {
   return (

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,29 +1,24 @@
-import { IonContent, IonHeader, IonIcon, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import { IonBackButton, IonButtons, IonContent, IonHeader, IonIcon, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 import SelectParentPlaceContainer from '../../components/select/SelectParentPlaceContainer';
 import './Home.css';
-import { bagOutline } from 'ionicons/icons';
+import { bagOutline, caretBack } from 'ionicons/icons';
 import { useState } from 'react';
 
 const Home: React.FC = () => {
-  const [title, setTitle] = useState("Home");
-
-  const handleTitle = (t: string) => {setTitle(t)}
-  
   return (
     <IonPage>
       <IonHeader>
         <IonToolbar>
-          <IonTitle>
-            <IonIcon icon={bagOutline}></IonIcon>{title}</IonTitle>
+          <IonTitle>Home</IonTitle>
         </IonToolbar>
       </IonHeader>
       <IonContent fullscreen>
         <IonHeader collapse="condense">
           <IonToolbar>
-            <IonTitle size="large">{title}</IonTitle>
+            <IonTitle size="large">Home</IonTitle>
           </IonToolbar>
         </IonHeader>
-        <SelectParentPlaceContainer handleTitle={handleTitle}/>
+        <SelectParentPlaceContainer/>
       </IonContent>
     </IonPage>
   );

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -2,22 +2,28 @@ import { IonContent, IonHeader, IonIcon, IonPage, IonTitle, IonToolbar } from '@
 import SelectParentPlaceContainer from '../../components/select/SelectParentPlaceContainer';
 import './Home.css';
 import { bagOutline } from 'ionicons/icons';
+import { useState } from 'react';
 
 const Home: React.FC = () => {
+  const [title, setTitle] = useState("Home");
+
+  const handleTitle = (t: string) => {setTitle(t)}
+  
   return (
     <IonPage>
       <IonHeader>
         <IonToolbar>
-          <IonTitle><IonIcon icon={bagOutline}></IonIcon>  Shop</IonTitle>
+          <IonTitle>
+            <IonIcon icon={bagOutline}></IonIcon>{title}</IonTitle>
         </IonToolbar>
       </IonHeader>
       <IonContent fullscreen>
         <IonHeader collapse="condense">
           <IonToolbar>
-            <IonTitle size="large">   Shop</IonTitle>
+            <IonTitle size="large">{title}</IonTitle>
           </IonToolbar>
         </IonHeader>
-        <SelectParentPlaceContainer />
+        <SelectParentPlaceContainer handleTitle={handleTitle}/>
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
## Qué se hizo?
* Se reincorporó el useRef para la referencia al parent place en el explorer.
* Se cambió el select por radio buttons en la vista de selección del parent place.
* El botón de _show map_ está deshabilitado hasta que se selecciona un parent place de la lista.

## Deuda técnica
* El mapa no se destruye cuando se vuelve a la vista de selección y el mapa no se destruye antes